### PR TITLE
First draft of the ZkVM spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # ZkVM
 
 An evolution of TxVM with **cloaked assets** and **zero-knowledge smart contracts**.
+
+## Specifications
+
+* [ZkVM specification](spec/ZkVM.md) — transaction validation rules,
+* [Blockchain specification](spec/Blockchain.md) — the blockchain state machine for the ZkVM transactions.
+
+The other protocols that are tightly integrated in the ZkVM:
+
+* [Merlin transcripts](https://doc.dalek.rs/merlin/index.html)
+* [Ristretto group](https://ristretto.group)
+* [Bulletproofs R1CS](https://doc-internal.dalek.rs/develop/bulletproofs/notes/r1cs_proof/index.html)
+* [Cloak](https://github.com/interstellar/spacesuit/blob/master/spec.md)
+* [Predicate Tree](spec/PredicateTree.md)
+* [Schnorr Proofs](spec/SchnorrProofs.md)
+* [Schnorr Aggregation](spec/SchnorrAggregation.md)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,3 @@ The other protocols that are tightly integrated in the ZkVM:
 * [Ristretto group](https://ristretto.group)
 * [Bulletproofs R1CS](https://doc-internal.dalek.rs/develop/bulletproofs/notes/r1cs_proof/index.html)
 * [Cloak](https://github.com/interstellar/spacesuit/blob/master/spec.md)
-* [Predicate Tree](spec/PredicateTree.md)
-* [Schnorr Proofs](spec/SchnorrProofs.md)
-* [Schnorr Aggregation](spec/SchnorrAggregation.md)

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -1,0 +1,265 @@
+# ZkVM
+
+This is the specification for ZkVM, the zero-knowledge transaction virtual machine.
+
+ZkVM defines a procedural representation for blockchain transactions and the rules for a virtual machine to interpret them and ensure their validity.
+
+* [Overview](#overview)
+    * [Motivation](#motivation)
+    * [Concepts](#concepts)
+* [Definitions](#definitions)
+    * [Types](#types)
+    * [Data types](#data-types)
+    * [Linear types](#linear-types)
+    * [Portable types](#portable-types)
+    * [Portable types](#portable-types)
+* [VM operation](#vm-operation)
+    * [VM state](#vm-state)
+    * [Encoding](#encoding)
+* [Discussion](#discussion)
+    * [Relation to TxVM](#relation-to-txvm)
+    * [Compatibility](#compatibility)
+
+
+
+
+
+
+
+## Overview
+
+### Motivation
+
+[TxVM](https://chain.com/assets/txvm.pdf) introduced a novel representation for the blockchain transactions:
+1. Each transaction is an executable program that produces effects to the blockchain state.
+2. Values as first-class types subject to [linear logic](http://girard.perso.math.cnrs.fr/Synsem.pdf).
+3. Contracts are first-class types that implement [object-capability model](https://en.wikipedia.org/wiki/Object-capability_model).
+
+The resulting design enables scalable blockchain state machine (since the state is very small, and its updates are separated from transaction verification), expressive yet safe smart contracts via the sound abstractions provided by the VM, simpler validation rules and simpler transaction format.
+
+TxVM, however, did not focus on privacy and in several places traded off simplicity for unlimited flexibility.
+
+ZkVM is the entirely new design that inherits most important insights from the TxVM, makes the security and privacy its primary focus, and provides a more constrained customization framework, while making the expression of most important contracts even more straightforward.
+
+### Concepts
+
+The transaction program, together with a version number and time bounds,
+is called the [transaction witness](#transaction-witness). It contains
+all data and logic required to produce a unique
+[transaction ID](#transaction-id). It also contains any necessary
+proofs (such as signatures) that do not contribute to the transaction ID.
+
+A [witness program](#witness-program) runs in the context of a
+stack-based virtual machine. When the virtual machine executes the program,
+it creates and manipulates data of various types:
+[data types](#data-types) (e.g. [scalars](#scalar-type) and [points](#point-type))
+and special [linear types](#linear-types) that include [values](#value-type) and
+[contracts](#contract-type).
+
+A _value_ is a specific amount of a specific asset that can be merged or split, issued or retired,
+but not otherwise created or destroyed.
+
+A _contract_ encapsulates a predicate (a public key or a program), plus its runtime state, and once created must be executed to completion or persisted in the global state for later execution.
+
+Some ZkVM instructions (such as storing a contract for later
+execution) propose alterations to the global blockchain state. These
+proposals accumulate in the [transaction log](#transaction-log), a
+data structure in the virtual machine that is the principal result of
+executing a transaction. Hashing the transaction log gives the unique
+[transaction ID](#transaction-id).
+
+A ZkVM transaction is valid if and only if it runs to completion
+without encountering failure conditions and without leaving any data
+on the stack.
+
+After a ZkVM program runs, the proposed state changes in the
+transaction log are compared with the global state to determine the
+transaction’s applicability to the [blockchain](Blockchain.md).
+
+
+
+
+
+
+
+
+
+
+## Definitions
+
+
+### Types
+
+The items on the ZkVM stack are typed. The available types fall into two
+broad categories: [data types](#data-types) and [linear types](#linear-types).
+
+
+### Data types
+
+Data types can be freely created, copied, and destroyed.
+
+* [Scalars](#scalars)
+* [Points](#points)
+* [Strings](#strings)
+* [Variables](#variables)
+* [Constraints](#constraints)
+
+
+### Linear types
+
+Linear types are subject to special rules as to when and how they may be created
+and destroyed, and may never be copied.
+
+* [Contracts](#contracts)
+* [Signed Values](#signed-values)
+* [Values](#values)
+
+
+### Portable types
+
+The items of the following types can be _ported_ across transactions via [outputs](#outputs):
+
+* [Plain data types](#data-types):
+    * [Scalars](#scalars)
+    * [Points](#points)
+    * [Strings](#strings)
+* [Values](#values)
+
+The [Signed Value](#signed-values) is not portable because it is not proven to be non-negative.
+
+The [Contract](#contracts) is not portable because it must be satisfied within the current transaction
+or [output](#outputs) its contents itself.
+
+The [Variable](#variables) and [Constraint](#constraints) types have no meaning outside the VM state
+and its constraint system and therefore cannot be ported between transactions.
+
+
+### Scalars
+
+A _scalar_ is an integer modulo [Ristretto group](https://ristretto.group) order `l`.
+
+`l = 2^252 + 27742317777372353535851937790883648493`
+
+Scalars are encoded as 32-byte arrays using little-endian notation.
+Every scalar in the VM is guaranteed to be in a canonical (reduced) form.
+
+
+### Points
+
+A _point_ is an element in the [Ristretto group](https://ristretto.group).
+
+Points are encoded as 32-byte arrays in _compressed Ristretto form_.
+Each point in the VM is guaranteed to be a valid Ristretto point.
+
+
+### Strings
+
+A _string_ is a variable-length byte array used to represent signatures, proofs and programs.
+
+Strings cannot be larger than the entire transaction program and cannot be longer than `2^32-1`.
+
+
+### Contracts
+
+A contract is a [predicate](#predicate) and a [payload](#payload) guarded by that predicate.
+
+Contracts are created with the [contract](#contract) instruction and
+destroyed by evaluating the predicate, leaving their stored items on the stack.
+
+Contracts can be "frozen" with the [output](#output) instruction that
+[encodes](#encoding) the predicate and the payload into the [output structure](#outputs) which is
+recorded in the [transaction log](#transaction-log).
+
+
+### Payload
+
+A list of [items](#types) stored in the [contract](#contracts) or [output](#outputs).
+
+Payload of a [contract](#contracts) may contain arbitrary [types](#types),
+but in the [output](#outputs) only the [portable types](#portable-types) are allowed.
+
+
+### Predicate
+
+Predicate is a representation of a condition that unlocks the [contract](#contracts).
+
+Predicate is encoded as a [point](#points) which can itself represent:
+
+* a verification key,
+* a set of verification keys,
+* a disjunction of nested predicates,
+* a [program](#program).
+
+Each contract can be opened by either:
+
+1. signing the [transaction ID](#transaction-id) with a key ([signtx](#signtx) instruction),
+2. revealing the embedded program and evaluating it ([call](#call) instruction),
+3. signing a _delegate program_ and evaluating it ([delegate](#delegate) instruction).
+
+Predicates can be selected from a tree of alternatives via [left](#left) and [right](#right) instructions.
+
+
+### Program
+
+
+
+
+## VM operation
+
+### VM state
+
+TBD:
+
+
+### Encoding
+
+TBD: encoding of the txlog items and snapshots
+
+
+
+## Discussion
+
+This section collects discussion of the rationale behind the design decisions in the ZkVM.
+
+### Relation to TxVM
+
+ZkVM has similar or almost identical properties as TxVM:
+
+1. The format of the transaction is the _executable bytecode_.
+2. The VM is a Forth-like _stack machine_.
+3. Multi-asset issuable _values_ are first-class types subject to _linear logic_.
+4. Contracts are first-class types implementing [object-capability model](https://en.wikipedia.org/wiki/Object-capability_model).
+5. VM assumes small UTXO-based blockchain state and very simple validation rules outside the VM.
+6. Each unspent transaction output (UTXO) is a _contract_ which holds arbitrary collection of data and values.
+7. Optional _time-bounded nonces_ as a way to guarantee uniqueness when transaction has no link to previous transactions.
+8. _Transaction log_ as an append-only list of effects of the transaction (inputs, outputs, nonces etc.)
+9. Contracts use linear logic by imperatively producing the effects they require instead of observing and verifying their context.
+10. Execution can be _delegated to a signed program_ which is provided at the moment of opening a contract.
+
+At the same time, ZkVM improves on the following tradeoffs in TxVM:
+
+1. _Runlimit_ and _jumps_: ZkVM does not permit recursion and loops and has more predictable cost model that does not require artificial cost metrics per instruction.
+2. _Too abstract capabilities_ that do not find their application in the practical smart contracts, like having “wrapping” contracts or many kinds of hash functions.
+3. Uniqueness of transaction IDs enforced via _anchors_ (embedded in values) is conceptually clean in TxVM, although not very ergonomic. In confidential transactions anchors become even less ergonomic in several respects, and issuance is simpler without anchors.
+4. TxVM allows multiple time bounds and needs to intersect all of them, which comes at odds with zero-knowledge proofs about time bounds.
+5. Creating outputs is less ergonomic and more complex than necessary (via a temporary contract).
+6. TxVM allows nested contracts and needs multiple stacks and an argument stack. ZkVM uses one stack.
+
+
+### Compatibility
+
+Forward- and backward-compatible upgrades (“soft forks”) are possible
+with [extension instructions](#ext), enabled by the
+[extension flag](#versioning) and higher version numbers.
+
+It is possible to write a compatible contract that uses features of a newer
+transaction version while remaining usable by non-upgraded software
+(that understands only older transaction versions) as long as
+new-version code paths are protected by checks for the transaction
+version. To facilitate that, a hypothetical ZkVM upgrade may introduce
+an extension instruction “version assertion” that fails execution if
+the version is below a given number (e.g. `4 versionverify`).
+
+
+
+

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -16,6 +16,7 @@ ZkVM defines a procedural representation for blockchain transactions and the rul
     * [String](#string-type)
     * [Contract](#contract-type)
     * [Variable](#variable-type)
+    * [Expression](#expression-type)
     * [Constraint](#constraint-type)
     * [Value](#value-type)
     * [Signed value](#signed-value)
@@ -234,15 +235,15 @@ when these are exposed to the VM (for instance, from [`zkmul`](#zkmul)), they ha
 A variable can be in one of two states: **detached** and **attached**.
 
 **Detached variable** can be [reblinded](#reblinded): all copies of a detached variable share the same commitment,
-so reblinding one of them reflects the new commitments in all the copies. When a [expression](#expression-type) is formed using detached variables, all of them transition to an _attached_ state.
+so reblinding one of them reflects the new commitments in all the copies. When an [expression](#expression-type) is formed using detached variables, all of them transition to an _attached_ state.
 
 **Attached variable** has its commitment applied to the constraint system, so it cannot be reblinded and variable cannot be detached.
 
 
 ### Expression type
 
-An expression is a linear combination of [variables](#variable-type) with cleartext [scalar](#scalar-type) weights.
-Expression is a super-type of a single variable: a variable can always be coerced to a linear combination containing one term with weight 1.
+_Expression_ is a linear combination of [variables](#variable-type) with cleartext [scalar](#scalar-type) weights.
+Expression is a supertype of a single variable: a variable can always be coerced to a linear combination containing one term with weight 1.
 
 Expressions can be [added](#zkadd) and [multiplied](#zkmul), producing new expressions.
 Expressions can also be [encrypted](#encrypt) into a [Pedersen commitment](#pedersen-commitment) with a predetermined

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -889,6 +889,17 @@ Merges and splits `m` [signed values](#signed-value-type) into `n` [values](#val
 
 Immediate data `m` and `n` are encoded as two 32-bit little-endian integers.
 
+#### import
+
+_..._ **import** → _value_
+
+TBD: Creates [value](#value) from the external blockchain.
+
+#### export
+
+_value ..._ **export** → ø
+
+TBD: Retires imported [value](#value) with annotation for export.
 
 
 
@@ -1005,19 +1016,32 @@ Fails if `x` is not a [data type](#data-types).
 
 #### peek
 
-**peek:k** → item
+_x[k] … x[0]_ **peek:_k_** → _x[k] ... x[0] x[k]_
 
-Copies k’th data item from the top of the stack. `0 peek:0` is equivalent to `dup`.
+Copies k’th data item from the top of the stack.
+Immediate data `k` is encoded as an unsigned byte.
 
-Immediate data `k` is encoded as unsigned byte.
+Fails if `x[k]` is not a [data type](#data-types).
+
+Note: `peek:0` is equivalent to `dup`.
 
 #### roll
 
-TBD
+_x[k] x[k-1] ... x[0]_ **roll:_k_** → _x[k-1] ... x[0] x[k]_
+
+Looks past `k` items from the top, and moves the next item to the top of the stack.
+Immediate data `k` is encoded as an unsigned byte.
+
+Note: `roll:0` is a no-op, `roll:1` swaps the top two items.
 
 #### bury
 
-TBD
+_x[k] ... x[1] x[0]_ **bury:_k_** → _x[0] x[k] ... x[1]_
+
+Moves the top item past the `k` items below it.
+Immediate data `k` is encoded as an unsigned byte.
+
+Note: `bury:0` is a no-op, `bury:1` swaps the top two items.
 
 
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -1131,26 +1131,26 @@ Code | Instruction                | Stack diagram                              |
 0x?? | [`unblind`](#unblind)      |        _v V expr_ → _var_                  | Modifies [CS](#constraint-system), [Defers point ops](#deferred-point-operations)
  |                                |                                            |
  |     [**Values**](#value-instructions)              |                        |
-0x?? | [`issue`](#issue)          |    _qty flv pred_ → _contract_             | Modifies [CS](#constraint-system), [tx log](#transaction-log)
+0x?? | [`issue`](#issue)          |    _qty flv pred_ → _contract_             | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
 0x?? | [`borrow`](#borrow)        |         _qty flv_ → _–V +V_                | Modifies [CS](#constraint-system)
 0x?? | [`retire`](#retire)        |           _value_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
-0x?? | [`qty`](#qty)              |     _signedvalue_ → _signedvalue qtyvar_   |
-0x?? | [`flavor`](#flavor)        |     _signedvalue_ → _signedvalue flavorvar_|
+0x?? | [`qty`](#qty)              |           _value_ → _value qtyvar_         |
+0x?? | [`flavor`](#flavor)        |           _value_ → _value flavorvar_      |
 0x?? | [`cloak:m:n`](#cloak)      | _signedvalues commitments_ → _values_      | Modifies [CS](#constraint-system)
-0x?? | [`import`](#import)        |   _proof qty flv_ → _value_                | Modifies [CS](#constraint-system), [tx log](#transaction-log)
+0x?? | [`import`](#import)        |   _proof qty flv_ → _value_                | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
 0x?? | [`export`](#export)        |       _value ???_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
  |                                |                                            |
  |     [**Contracts**](#contract-instructions)        |                        |
 0x?? | [`input`](#input)          |           _input_ → _contract_             | Modifies [tx log](#transaction-log)
-0x?? | [`output:k`](#output)      | _items... predicate_ → ø                   | Modifies [tx log](#transaction-log)
-0x?? | [`contract:k`](#contract)  | _items... predicate_ → _contract_          | 
-0x?? | [`nonce`](#nonce)          |          _predicate_ → _contract_          | Modifies [tx log](#transaction-log)
-0x?? | [`data`](#data)            |               _item_ → ø                   | Modifies [tx log](#transaction-log)
-0x?? | [`signtx`](#signtx)        |           _contract_ → _results..._        | Modifies [deferred verification keys](#signature)
-0x?? | [`call`](#call)            |      _contract prog_ → _results..._        | [Defers point operations](#deferred-point-operations)
-0x?? | [`left`](#left)            |       _contract A B_ → _contract’_         | [Defers point operations](#deferred-point-operations)
-0x?? | [`right`](#right)          |       _contract A B_ → _contract’_         | [Defers point operations](#deferred-point-operations)
-0x?? | [`delegate`](#delegate)    |  _contract prog sig_ → _results..._        | [Defers point operations](#deferred-point-operations)
+0x?? | [`output:k`](#output)      |   _items... pred_ → ø                      | Modifies [tx log](#transaction-log)
+0x?? | [`contract:k`](#contract)  |   _items... pred_ → _contract_             | 
+0x?? | [`nonce`](#nonce)          |            _pred_ → _contract_             | Modifies [tx log](#transaction-log)
+0x?? | [`data`](#data)            |            _item_ → ø                      | Modifies [tx log](#transaction-log)
+0x?? | [`signtx`](#signtx)        |        _contract_ → _results..._           | Modifies [deferred verification keys](#signature)
+0x?? | [`call`](#call)            |   _contract prog_ → _results..._           | [Defers point operations](#deferred-point-operations)
+0x?? | [`left`](#left)            |    _contract A B_ → _contract’_            | [Defers point operations](#deferred-point-operations)
+0x?? | [`right`](#right)          |    _contract A B_ → _contract’_            | [Defers point operations](#deferred-point-operations)
+0x?? | [`delegate`](#delegate)    |_contract prog sig_ → _results..._          | [Defers point operations](#deferred-point-operations)
  |                                |                                            |
  |     [**Stack**](#stack-instructions)               |                        |
 0x?? | [`dup`](#dup)              |               _x_ → _x x_                  |

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -450,7 +450,7 @@ h = T.challenge_scalar("h")
 PP(prog) = h·B2
 ```
 
-Program predicate can be satisfied only via the [`call`](#call) instruction that takes a cleartext program string, verifies the commitment and evaluates the program. Use of the [secondary base point](#base-points) `B2` prevents using the predicate as a [verification key](#verification-key)) and signing with `h` without executing it.
+Program predicate can be satisfied only via the [`call`](#call) instruction that takes a cleartext program string, verifies the commitment and evaluates the program. Use of the [secondary base point](#base-points) `B2` prevents using the predicate as a [verification key](#verification-key)) and signing with `h` without executing the program.
 
 
 ### Program
@@ -1421,22 +1421,25 @@ Fails if:
 
 _qtyc pred_ **issue** → _contract_
 
-1. Pops [points](#point-type) `pred`, then `qtyc` from the stack.
-2. Creates a value with quantity represented by a [Pedersen commitment](#pedersen-commitment) _qtyc_ and flavor defined by the [predicate](#predicate) `pred` using the following [transcript-based](#transcript) protocol:
+1. Pops [point](#point-type) `pred`.
+2. Pops [point](#point-type) `qtyc`.
+3. Creates a value with quantity represented by a [Pedersen commitment](#pedersen-commitment) _qtyc_ and flavor defined by the [predicate](#predicate) `pred` using the following [transcript-based](#transcript) protocol:
     ```
     T = Transcript("ZkVM.issue")
     T.commit("predicate", pred)
     flavor = T.challenge_scalar("flavor")
     F = flavor·B  (non-blinded Pedersen commitment)
     ```
-3. Adds a 64-bit range proof for the quantity variable to the [constraint system](#constraint-system) (see [Cloak protocol](https://github.com/interstellar/spacesuit/blob/master/spec.md) for the range proof definition). 
-4. Adds an [issue entry](#issue-entry) to the [transaction log](#transaction-log).
-5. Creates a [contract](#contract-type) with the value as the only [payload](#contract-payload), with the predicate `pred`.
+4. Adds a 64-bit range proof for the quantity variable to the [constraint system](#constraint-system) (see [Cloak protocol](https://github.com/interstellar/spacesuit/blob/master/spec.md) for the range proof definition). 
+5. Adds an [issue entry](#issue-entry) to the [transaction log](#transaction-log).
+6. Creates a [contract](#contract-type) with the value as the only [payload](#contract-payload), with the predicate `pred`.
 
 The value is now issued into the contract that must be unlocked
 using one of the contract instructions: [`signtx`](#signx), [`delegate`](#delegate) or [`call`](#call).
 
-TBD: customization tag, maybe hidden via commitment? Cleartext tag is useless because it can be embedded in a predicate.
+TBD: the `F` must be provided by the user so the check `F == flavor*B` can be merged with deferred point ops.
+
+TBD: change to accept detached vars
 
 Fails if either `qtyc` or `pred` are not [point types](#point-type).
 
@@ -1457,6 +1460,7 @@ The signed value `–V` is not a [portable type](#portable-types), and can only 
 
 Fails if either `qtyc` or `flavorc` are not [point types](#point-type).
 
+TBD: change to accept detached vars
 
 #### retire
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -2047,7 +2047,7 @@ Also, it's not private enough: the contract now not only reveals its logic, but 
 
 Now let’s see how [`borrow`](#borrow) simplifies things: it allows you to make $X out of thin air, "borrowing" it from void for the duration of the transaction.
 
-`borrow` gives you a positive $X as requested, but it also needs to require you to repay $X from some other source before tx is finalized. This is represented by creating a *negative –$X* as a less powerful type SignedValue.
+`borrow` gives you a positive $X as requested, but it also needs to require you to repay $X from some other source before tx is finalized. This is represented by creating a *negative –$X* as a less powerful type Signed Value.
 
 Signed values are less powerful (they are super-types of Values) because they are not _portable_. You cannot just stash such value away in some output. You have to actually repay it using the `cloak` instruction.
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -40,6 +40,16 @@ ZkVM defines a procedural representation for blockchain transactions and the rul
     * [Value instructions](#value-instructions)
     * [Contract instructions](#contract-instructions)
     * [Stack instructions](#stack-instructions)
+* [Examples](#examples)
+    * [Lock value example](#lock-value-example)
+    * [Unlock value example](#unlock-value-example)
+    * [Simple payment example](#simple-payment-example)
+    * [Offer example](#offer-example)
+    * [Offer with partial lift](#offer-with-partial-lift)
+    * [Loan example](#loan-example)
+    * [Loan with interest](#loan-with-interest)
+    * [Payment channel example](#payment-channel-example)
+    * [Payment routing example](#payment-routing-example)
 * [Discussion](#discussion)
     * [Relation to TxVM](#relation-to-txvm)
     * [Compatibility](#compatibility)
@@ -1052,6 +1062,55 @@ Moves the top item past the `k` items below it.
 Immediate data `k` is encoded as an unsigned byte.
 
 Note: `bury:0` is a no-op, `bury:1` swaps the top two items.
+
+
+
+
+
+
+
+
+
+## Examples
+
+### Lock value example
+
+TBD.
+
+### Unlock value example
+
+TBD.
+
+### Simple payment example
+
+TBD.
+
+### Offer example
+
+TBD.
+
+### Offer with partial lift
+
+TBD.
+
+### Loan example
+
+TBD.
+
+### Loan with interest
+
+TBD.
+
+### Payment channel example
+
+TBD.
+
+### Payment routing example
+
+TBD.
+
+
+
 
 
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -103,7 +103,7 @@ Data types can be freely created, copied, and destroyed.
 * [Points](#points)
 * [Strings](#strings)
 * [Variables](#variables)
-* [Constraints](#constraints)
+* [Constraints](#constraint)
 
 
 ### Linear types
@@ -131,7 +131,7 @@ The [Signed Value](#signed-values) is not portable because it is not proven to b
 The [Contract](#contracts) is not portable because it must be satisfied within the current transaction
 or [output](#outputs) its contents itself.
 
-The [Variable](#variables) and [Constraint](#constraints) types have no meaning outside the VM state
+The [Variable](#variables) and [Constraint](#constraint) types have no meaning outside the VM state
 and its constraint system and therefore cannot be ported between transactions.
 
 
@@ -175,11 +175,11 @@ Strings cannot be larger than the entire transaction program and cannot be longe
 
 A contract is a [predicate](#predicate) and a [payload](#payload) guarded by that predicate.
 
-Contracts are created with the [contract](#contract) instruction and
+Contracts are created with the [`contract`](#contract) instruction and
 destroyed by evaluating the predicate, leaving their stored items on the stack.
 
-Contracts can be "frozen" with the [output](#output) instruction that
-[encodes](#encoding) the predicate and the payload into the [output structure](#outputs) which is
+Contracts can be "frozen" with the [`output`](#output) instruction that
+[encodes](#encoding) the predicate and the payload into the [output structure](#output-structure) which is
 recorded in the [transaction log](#transaction-log).
 
 
@@ -204,11 +204,11 @@ Predicate is encoded as a [point](#points) which can itself represent:
 
 Each contract can be opened by either:
 
-1. signing the [transaction ID](#transaction-id) with a key ([signtx](#signtx) instruction),
-2. revealing the embedded program and evaluating it ([call](#call) instruction),
-3. signing a _delegate program_ and evaluating it ([delegate](#delegate) instruction).
+1. signing the [transaction ID](#transaction-id) with a key ([`signtx`](#signtx) instruction),
+2. revealing the embedded program and evaluating it ([`call`](#call) instruction),
+3. signing a _delegate program_ and evaluating it ([`delegate`](#delegate) instruction).
 
-Predicates can be selected from a tree of alternatives via [left](#left) and [right](#right) instructions.
+Predicates can be selected from a tree of alternatives via [`left`](#left) and [`right`](#right) instructions.
 
 
 ### Verification key
@@ -225,6 +225,11 @@ where:
 * `P` is a verification key,
 * `x` is a signing key (secret scalar),
 * `B` is the [primary base point](#base-points).
+
+#### See also
+
+* [Predicate](#predicate)
+* [Signature](#signature)
 
 
 ### Program
@@ -244,7 +249,7 @@ See the [instruction set](#instructions) for definition of the immediate data fo
 The part of the [VM state](#vm-state) that implements
 [Bulletprofs Rank-1 Constraint System](https://doc-internal.dalek.rs/develop/bulletproofs/notes/r1cs_proof/index.html).
 
-Constraint system keeps track of [variables](#variables) and [constraints](#constraints).
+Constraint system keeps track of [variables](#variables) and [constraints](#constraint).
 
 ### Variables
 
@@ -252,14 +257,19 @@ _Variable_ is a linear combination of high-level and low-level variables in the 
 
 Variables can be added and multiplied, producing new variables (see [`zkadd`](#zkadd), [`zkneg`](#zkneg), [`zkmul`](#zkmul), [`scmul`](#scmul) and [`zkrange`](#zkrange) instructions).
 
-Equality of two variables is checked by creating a [constraint](#constraints) using the [`zkeq`](#zkeq) instruction.
+Equality of two variables is checked by creating a [constraint](#constraint) using the [`zkeq`](#zkeq) instruction.
 
 Examples of variables: [value quantities](#values) and [time bounds](#time-bounds).
 
 Cleartext [scalars](#scalars) can be turned into a `Variable` type using the [`const`](#const) instruction.
 
+#### See also
 
-### Constraints
+* [Constraint](#constrain)
+* [Constraint system](#constraint-system)
+
+
+### Constraint
 
 _Constraint_ is a statement in the [constraint system](#constraint-system) that constrains
 a linear combination of variables to zero.
@@ -268,6 +278,11 @@ Constraints are created using the [`zkeq`](#zkeq) instruction over two [variable
 
 Constraints can be combined using logical [`and`](#and) and [`or`](#or) instructions and added to the constraint
 system using the [verify](#verify) instruction.
+
+#### See also
+
+* [Variable](#variable)
+* [Constraint system](#constraint-system)
 
 
 ### Commitment
@@ -308,7 +323,7 @@ A value is a [linear type](#linear-types) representing a pair of *quantity* and 
 Both quantity and flavor are represented as [scalars](#scalars).
 Quantity is guaranteed to be in a 64-bit range (`[0..2^64-1]`).
 
-Values are created with [issue](#issue) and destroyed with [retire](#retire).
+Values are created with [`issue`](#issue) and destroyed with [`retire`](#retire).
 
 A value can be merged and split together with other values using a [`cloak`](#cloak) instruction.
 Only values having the same flavor can be merged.
@@ -340,18 +355,18 @@ Signature is encoded as a 64-byte [string](#strings).
 The signature verification protocol is the following:
 
 ```
-Prover                                  Verifier
-------------------------------------------------
+Prover                                              Verifier
+------------------------------------------------------------
 P := x*B
-                      T("ZkVM.Signature")
-                      T <- ("P", P)
-                      T <- ("M", message)
-r := random   
+                 T("ZkVM.Signature")
+                          T <- ("P", P)
+                          T <- ("M", message)
+r := random       
 R := r*B   
-                      T <- ("R", R)
-                 e <- T
+                          T <- ("R", R)
+                     e <- T
 s := r + e*x
-                                 s*G =?= R + e*P
+                                             s*G =?= R + e*P
 ```
 
 where:
@@ -396,18 +411,18 @@ The transaction log is empty at the beginning of a ZkVM program. It is
 append-only. Items are added to it upon execution of any of the
 following instructions:
 
-* [finalize](#finalize)
-* [input](#input)
-* [issue](#issue)
-* [data](#data)
-* [nonce](#nonce)
-* [output](#output)
-* [retire](#retire)
+* [`finalize`](#finalize)
+* [`input`](#input)
+* [`issue`](#issue)
+* [`data`](#data)
+* [`nonce`](#nonce)
+* [`output`](#output)
+* [`retire`](#retire)
 
 The details of the item added to the log differs for each
 instruction. See the instruction’s description for more information.
 
-The [finalize](#finalize) instruction prohibits further changes to the
+The [`finalize`](#finalize) instruction prohibits further changes to the
 transaction log. Every ZkVM program must execute `finalize` exactly
 once.
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -762,6 +762,9 @@ Aggregation protocol is:
 
 ### Blinding proof protocol
 
+TBD: this protocol is obsolete. See the encrypt/decrypt spec for up to date sketches.
+
+
 A zero-knowledge protocol that proves that a [Pedersen commitment](#pedersen-commitment) contains a 
 pre-committed blinding factor. This protocol allows proving to the network that a payment is accessible
 to the recipient (since the blinding factor is already known to the recipient), while allowing

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -150,7 +150,7 @@ and its constraint system and therefore cannot be ported between transactions.
 
 ### Scalar type
 
-A _scalar_ is an integer modulo [Ristretto group](https://ristretto.group) order `2^252 + 27742317777372353535851937790883648493`.
+A _scalar_ is an integer modulo [Ristretto group](https://ristretto.group) order `|G| = 2^252 + 27742317777372353535851937790883648493`.
 
 Scalars are encoded as 32-byte arrays using little-endian notation.
 Every scalar in the VM is guaranteed to be in a canonical (reduced) form.
@@ -363,9 +363,7 @@ The signature verification protocol is the following:
 Prover                                              Verifier
 ------------------------------------------------------------
 P := x*B
-                 T("ZkVM.Signature")
                           T <- ("P", P)
-                          T <- ("M", message)
 r := random       
 R := r*B   
                           T <- ("R", R)
@@ -590,9 +588,9 @@ Instruction                | Stack diagram                              | Effect
 [`point:x`](#point)        |                 ø → _point_                | 
 [`string:n:x`](#string)    |                 ø → _string_               | 
 [**Scalars**](#scalar-instructions)            |                        | 
-[`neg`](#neg)              |               _a_ → _l–a_                  | 
-[`add`](#add)              |             _a b_ → _a+b mod l_            | 
-[`mul`](#mul)              |             _a b_ → _a·b mod l_            | 
+[`neg`](#neg)              |               _a_ → _\|G\|–a_              | 
+[`add`](#add)              |             _a b_ → _a+b mod \|G\|_        | 
+[`mul`](#mul)              |             _a b_ → _a·b mod \|G\|_        | 
 [`eq`](#eq)                |             _a b_ → ø                      | Fails if _a_ ≠ _b_.
 [`range:n`](#range)        |               _a_ → _a_                    | Fails if _a_ is not in range [0..2^64-1]
 [**Constraints**](#constraint-system-instructions)  |                   | 
@@ -1066,7 +1064,6 @@ new-version code paths are protected by checks for the transaction
 version. To facilitate that, a hypothetical ZkVM upgrade may introduce
 an extension instruction “version assertion” that fails execution if
 the version is below a given number (e.g. `4 versionverify`).
-
 
 
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -886,7 +886,7 @@ Code | Instruction                | Stack diagram                              |
 0x?? | [`or`](#or)                | _constr1 constr2_ → _constr3_              |
 0x?? | [`verify`](#verify)        |      _constraint_ → ø                      | Modifies [CS](#constraint-system) 
 0x?? | [`encrypt`](#encrypt)      |     _X F V proof_ → _V_                    | [Defers point operations](#deferred-point-operations)
-0x?? | [`decrypt`](#decrypt)      |        _V scalar_ → _V_                    | [Defers point operations](#deferred-point-operations))
+0x?? | [`decrypt`](#decrypt)      |        _V scalar_ → _V_                    | [Defers point operations](#deferred-point-operations)
  |                                |                                            |
  |     [**Values**](#value-instructions)              |                        |
 0x?? | [`issue`](#issue)          |       _qtyc pred_ → _contract_             | Modifies [CS](#constraint-system), [tx log](#transaction-log)

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -669,7 +669,9 @@ T.commit("import", proof)
 
 Export entry is added using [`export`](#export) instruction.
 
-TBD.
+```
+T.commit("export", metadata)
+```
 
 
 
@@ -1560,7 +1562,7 @@ _proof qty flv_ **import** → _value_
     ```
     qty == proof.quantity·B
     ```
-8. Adds an [import entry](#import-entry) to the [transaction log](#transaction-log).
+8. Adds an [import entry](#import-entry) with `proof` to the [transaction log](#transaction-log).
 9. Pushes the imported value to the stack.
 
 Note: the `proof` string contains necessary metadata to check if the value is pegged on the external blockchain.
@@ -1576,9 +1578,29 @@ Fails if:
 
 #### export
 
-_value ..._ **export** → ø
+_metadata value_ **export** → ø
 
-TBD: Retires imported [value](#value) with annotation for export.
+1. Pops [value](#value-type).
+2. Pops [string](#string-type) `metadata`.
+3. Computes the local flavor based on the pegging metadata:
+    ```
+    T = Transcript("ZkVM.import")
+    T.commit("extflavor", metadata.external_flavor_id)
+    T.commit("extaccount", metadata.pegging_account_id)
+    flavor = T.challenge_scalar("flavor")
+    ```
+4. Adds two constraints to the constraint system using cleartext quantity and flavor in the metadata:
+    ```
+    value.qty == metadata.qty
+    value.flv == flavor
+    ```
+5. Adds an [export entry](#export-entry) with `metadata` to the [transaction log](#transaction-log).
+
+TBD: definition of the metadata string (quantity, asset id, pegging account, target address/accountid)
+
+Fails if:
+* `value` is not a [non-negative value type](#value-type),
+* `metadata` is not a [string type](#string-type).
 
 
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -63,7 +63,7 @@ The resulting design enables scalable blockchain state machine (since the state 
 
 TxVM, however, did not focus on privacy and in several places traded off simplicity for unlimited flexibility.
 
-ZkVM is the entirely new design that inherits most important insights from the TxVM, makes the security and privacy its primary focus, and provides a more constrained customization framework, while making the expression of most important contracts even more straightforward.
+ZkVM is the entirely new design that inherits most important insights from the TxVM, makes the security and privacy its primary focus, and provides a more constrained customization framework, while making the expression of the most common contracts even more straightforward.
 
 ### Concepts
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -1116,8 +1116,9 @@ Code | Instruction                | Stack diagram                              |
 0x?? | [`range:n`](#range)        |               _a_ → _a_                    | Fails if _a_ is not in range [0..2^64-1]
  |                                |                                            |
  |     [**Constraints**](#constraint-system-instructions)  |                   | 
-0x?? | [`var`](#var)              |           _point_ → _var_                  | Adds an external variable to [CS](#constraint-system)
 0x?? | [`const`](#var)            |          _scalar_ → _expr_                 | 
+0x?? | [`var`](#var)              |           _point_ → _var_                  | Adds an external variable to [CS](#constraint-system)
+0x?? | [`alloc`](#alloc)          |                 ø → _expr_                 | Allocates a low-level variable in [CS](#constraint-system)
 0x?? | [`mintime`](#mintime)      |                 ø → _expr_                 |
 0x?? | [`maxtime`](#maxtime)      |                 ø → _expr_                 |
 0x?? | [`zkneg`](#zkneg)          |           _expr1_ → _expr2_                |
@@ -1243,6 +1244,16 @@ Fails if:
 
 ### Constraint system instructions
 
+#### const
+
+_a_ **const** → _expr_
+
+1. Pops a [scalar](#scalar-type) `a` from the stack.
+2. Creates an [expression](#expression-type) `expr` with weight `a` assigned to an R1CS constant `1`.
+3. Pushes `expr` to the stack.
+
+Fails if `a` is not a [scalar type](#scalar-type).
+
 #### var
 
 _P_ **var** → _v_
@@ -1253,15 +1264,15 @@ _P_ **var** → _v_
 
 Fails if `P` is not a [point type](#point-type).
 
-#### const
+#### alloc
 
-_a_ **const** → _expr_
+**alloc** → _expr_
 
-1. Pops a [scalar](#scalar-type) `a` from the stack.
-2. Creates an [expression](#expression-type) `expr` with weight `a` assigned to an R1CS constant `1`.
-3. Pushes `expr` to the stack.
+1. Allocates a low-level variable in the [constraint system](#constraint-system) and wraps it in the [expression](#expression-type) with weight 1.
+2. Pushes the resulting expression to the stack.
 
-Fails if `a` is not a [scalar type](#scalar-type).
+This is different from [`var`](#var) in that the variable is not represented by an individual commitment and therefore can be chosen freely when the transaction is formed.
+
 
 #### mintime
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -418,6 +418,16 @@ The proof is provided to the VM at the beggining of execution and verified when 
 
 ### Transcript
 
+Transcript is an instance of the [Merlin](https://doc.dalek.rs/merlin/) construction,
+which is itself based on [STROBE](https://strobe.sourceforge.io/) and [Keccak-f](https://keccak.team/keccak.html)
+with 128-bit security parameter.
+
+Transcript is used throughout ZkVM to generate challenge [scalars](#scalar-type) and various hash-based commitments.
+
+
+
+
+
 TBD: merlin/strobe, protocol label, challenge scalar, labeled inputs.
 
 
@@ -672,25 +682,25 @@ followed by `x` encoded as a sequence of `n` bytes.
 
 #### neg
 
-_a_ **neg** → _(l–a)_
+_a_ **neg** → _(|G|–a)_
 
-Negates the [scalar](#scalar-type) `a` modulo Ristretto group order `l`.
+Negates the [scalar](#scalar-type) `a` modulo Ristretto group order `|G|`.
 
 Fails if item `a` is not of type [Scalar](#scalar-type).
 
 #### add
 
-_a b_ **add** → _(a+b mod l)_
+_a b_ **add** → _(a+b mod |G|)_
 
-Adds [scalars](#scalar-type) `a` and `b` modulo Ristretto group order `l`.
+Adds [scalars](#scalar-type) `a` and `b` modulo Ristretto group order `|G|`.
 
 Fails if either `a` or `b` is not of type [Scalar](#scalar-type).
 
 #### mul
 
-_a b_ **mul** → _(a·b mod l)_
+_a b_ **mul** → _(a·b mod |G|)_
 
-Multiplies [scalars](#scalar-type) `a` and `b` modulo Ristretto group order `l`.
+Multiplies [scalars](#scalar-type) `a` and `b` modulo Ristretto group order `|G|`.
 
 Fails if either `a` or `b` is not of type [Scalar](#scalar-type).
 
@@ -1080,6 +1090,12 @@ At the same time, ZkVM improves on the following tradeoffs in TxVM:
 Forward- and backward-compatible upgrades (“soft forks”) are possible
 with [extension instructions](#ext), enabled by the
 [extension flag](#versioning) and higher version numbers.
+
+For instance, to implement a SHA-256 function, an unsued extension instruction
+could be assigned `verifysha256` name and check if top two strings on the stack
+are preimage and image of the SHA-256 function respectively. The VM would fail if
+the check failed, while the non-upgraded software could choose to treat the instruction as no-op
+(e.g. by ignoring the upgraded transaction version).
 
 It is possible to write a compatible contract that uses features of a newer
 transaction version while remaining usable by non-upgraded software

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -527,22 +527,19 @@ Extensions:
 
 ## Instructions
 
-[Data instructions](#data-instructions)  | Stack diagram                | Effects
+Instructions               | Stack diagram                              | Effects
 ---------------------------|--------------------------------------------|----------------------------------
+[**Data**](#data-instructions)  |                                       |
 [`scalar:x`](#scalar)      |                 ø → _scalar_               | 
 [`point:x`](#point)        |                 ø → _point_                | 
 [`string:n:x`](#string)    |                 ø → _string_               | 
-
-[Scalar instructions](#scalar-instructions)  | Stack diagram            | Effects
----------------------------|--------------------------------------------|----------------------------------
+[**Scalars**](#scalar-instructions)  |                                  | 
 [`add`](#add)              |             _a b_ → _a+b mod l_            | 
 [`neg`](#neg)              |               _a_ → _l–a_                  | 
 [`mul`](#mul)              |             _a b_ → _a·b mod l_            | 
 [`eq`](#eq)                |             _a b_ → ø                      | Fails if _a_ ≠ _b_.
 [`range:n`](#range)        |               _a_ → _a_                    | Fails if _a_ is not in range [0..2^64-1]
-
-[CS instructions](#constraint-system-instructions)  | Stack diagram     | Effects
----------------------------|--------------------------------------------|----------------------------------
+[**Constraints**](#constraint-system-instructions)  |                   | 
 [`var`](#var)              |           _point_ → _var_                  | Adds an external variable to [CS](#constraint-system)
 [`const`](#var)            |          _scalar_ → _var_                  | 
 [`mintime`](#mintime)      |                 ø → _var_                  |
@@ -558,9 +555,7 @@ Extensions:
 [`verify`](#verify)        |      _constraint_ → ø                      | Modifies [CS](#constraint-system) 
 [`encrypt`](#encrypt)      |     _X F V proof_ → _V_                    | Modifies [point operations](#point-operations)
 [`decrypt`](#decrypt)      |        _scalar V_ → _V_                    | Modifies [point operations](#point-operations)
-
-[Value instructions](#value-instructions)  | Stack diagram              | Effects
----------------------------|--------------------------------------------|----------------------------------
+[**Values**](#value-instructions)  |                                    |
 [`issue`](#issue)          | _qtycommitment predicate_ → _contract_     | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 [`borrow`](#borrow)        | _qtycommitment flvrcommitment_ → _+V –V_   | Modifies [CS](#constraint-system)
 [`retire`](#retire)        | _value_ → ø                                | Modifies [CS](#constraint-system), [tx log](#transaction-log)
@@ -569,9 +564,7 @@ Extensions:
 [`cloak:m:n`](#cloak)      | _signedvalues commitments???_ → _values_   | Modifies [CS](#constraint-system)
 [`import`](#import)        | _???_ → _value_                            | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 [`export`](#export)        | _value ???_ → ø                            | Modifies [CS](#constraint-system), [tx log](#transaction-log)
-
-[Contract instructions](#contract-instructions)  | Stack diagram        | Effects
----------------------------|--------------------------------------------|----------------------------------
+[**Contracts**](#contract-instructions)  |                              |
 [`inputs:n`](#inputs)      | _snapshots... predicates..._ → _contracts_ | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 [`output:n`](#output)      | _items... predicatecommitment_ → ø         | Modifies [tx log](#transaction-log)
 [`contract:n`](#contract)  | _items... predicate_ → _contract_          | 
@@ -582,9 +575,7 @@ Extensions:
 [`left`](#left)            |       _contract A B_ → _contract’_         | Modifies [point operations](#point-operations)
 [`right`](#right)          |       _contract A B_ → _contract’_         | Modifies [point operations](#point-operations)
 [`delegate`](#delegate)    |  _contract prog sig_ → _results..._        | Modifies [point operations](#point-operations)
-
-[Stack instructions](#stack-instructions)  | Stack diagram              | Effects
----------------------------|--------------------------------------------|----------------------------------
+[**Stack**](#stack-instructions)  |                                     | 
 [`dup`](#dup)              |               _x_ → _x x_                  |
 [`drop`](#drop)            |               _x_ → ø                      |
 [`peek:n`](#peek)          |     _x[n] … x[0]_ → _x[n] ... x[0] x[n]_   |

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -136,9 +136,7 @@ and its constraint system and therefore cannot be ported between transactions.
 
 ### Scalars
 
-A _scalar_ is an integer modulo [Ristretto group](https://ristretto.group) order `l`.
-
-`l = 2^252 + 27742317777372353535851937790883648493`
+A _scalar_ is an integer modulo [Ristretto group](https://ristretto.group) order `2^252 + 27742317777372353535851937790883648493`.
 
 Scalars are encoded as 32-byte arrays using little-endian notation.
 Every scalar in the VM is guaranteed to be in a canonical (reduced) form.
@@ -198,8 +196,37 @@ Each contract can be opened by either:
 
 Predicates can be selected from a tree of alternatives via [left](#left) and [right](#right) instructions.
 
+See the [Predicate Tree](PredicateTree.md) specification for additional details.
+
 
 ### Program
+
+A program is a string containing a sequence of ZkVM [instructions](#instructions).
+Each instruction is an **opcode** optionally followed by **immediate data**.
+
+The **opcode** is a one-byte unsigned integer.
+
+The **immediate data** is 0 or more bytes, depending on the opcode.
+
+See the [instruction set](#instructions) for definition of the immediate data for each opcode.
+
+
+### Variables
+
+_Variable_ is a linear combination of high-level and low-level variables in the
+[Bulletprofs Rank-1 Constraint System](https://doc-internal.dalek.rs/develop/bulletproofs/notes/r1cs_proof/index.html).
+
+Variables can be added and multiplied, producing new variables (see [zkadd](#zkadd), [zkneg](#zkneg), [zkmul](#zkmul), [scmul](#scmul) and [zkrange](#zkrange) instructions).
+
+Variables can used to form [constraints](#constraints) using the equality instruction [zkeq](#zkeq).
+
+Examples of variables: [value quantities](#qty) and [time bounds](#maxtime).
+
+Cleartext [scalars](#scalars) can be turned into a `Variable` type using the [const](#const) instruction.
+
+
+### Constraints
+
 
 
 
@@ -208,7 +235,7 @@ Predicates can be selected from a tree of alternatives via [left](#left) and [ri
 
 ### VM state
 
-TBD:
+TBD: the header, the stack, program stack, txlog, CS, schnorr ops.
 
 
 ### Encoding

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -559,7 +559,7 @@ Signature is encoded as a 64-byte [string](#string-type).
 
 The protocol is the following:
 
-1. Prover and verifier obtain a [transcript](#transcript) `T` defined by the context in which the signature is used (see [`signtx`](#signtx), [`delegate`](#delegate)). The transcript is assumed to be already bound to the _message_ and the [verification key](#verification-key) `P`.
+1. Prover and verifier obtain a [transcript](#transcript) `T` defined by the context in which the signature is used (see [`signtx`](#signtx), [`delegate`](#delegate)). The transcript is assumed to be already bound to the _message_ and the [verification key](#verification-key) `P`.
 2. Prover creates a _secret nonce_, randomly sampled [scalar](#scalar-type) `r`.
 3. Prover commits to nonce:
     ```
@@ -583,7 +583,6 @@ The protocol is the following:
     ```
     s·B == R + e·P
     ```
-
 
 ### Aggregated transaction signature
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -639,25 +639,25 @@ Instruction                | Stack diagram                              | Effect
 
 ### Data instructions
 
-#### point
-
-**point:x** → _point_
-
-Pushes a [point](#point-type) `x` to the stack. `x` is a 32-byte immediate data.
-
-Fails if the point is not a valid compressed Ristretto point.
-
 #### scalar
 
-**scalar:x** → _scalar_
+**scalar:_x_** → _scalar_
 
 Pushes a [scalar](#scalar-type) `x` to the stack. `x` is a 32-byte immediate data.
 
 Fails if the scalar is not canonically encoded (reduced modulo Ristretto group order).
 
+#### point
+
+**point:_x_** → _point_
+
+Pushes a [point](#point-type) `x` to the stack. `x` is a 32-byte immediate data.
+
+Fails if the point is not a valid compressed Ristretto point.
+
 #### string
 
-**string:n:x** → _string_
+**string:_n_:_x_** → _string_
 
 Pushes a [string](#string-type) `x` containing `n` bytes. 
 Immediate data `n` is encoded as little-endian 32-bit integer
@@ -703,7 +703,7 @@ Fails if either `a` or `b` is not of type [Scalar](#scalar-type).
 
 #### range
 
-_a_ **range:n** → _a_
+_a_ **range:_n_** → _a_
 
 Checks that the [scalar](#scalar-type) `a` is in `n`-bit range. Immediate data `n` is 1 byte and must be in [1,64] range.
 
@@ -776,7 +776,7 @@ Pushes a linear constraint `var1 - var2 = 0`
 
 #### zkrange
 
-_v_ **zkrange:n** → _v_
+_v_ **zkrange:_n_** → _v_
 
 Checks that variable is in n-bit range. Immediate data n is 1-byte and must be in [1,64] range.
 
@@ -877,7 +877,7 @@ Copies a [variable](#variable-type) representing flavor of a [signed value](#sig
 
 #### cloak
 
-_signedvalues commitments_ **cloak:m\:n** → _values_
+_signedvalues commitments_ **cloak:_m_:_n_** → _values_
 
 Merges and splits `m` [signed values](#signed-value-type) into `n` [values](#values).
 
@@ -896,7 +896,7 @@ Immediate data `m` and `n` are encoded as two 32-bit little-endian integers.
 
 #### inputs
 
-_snapshots predicates_ **inputs:m** → _contracts_ 
+_snapshots predicates_ **inputs:_m_** → _contracts_
 
 TBD.
 
@@ -909,13 +909,13 @@ Resulting contracts are sorted the same way as predicates, and have number stack
 
 #### output
 
-_items predicatecommitment_ **output:k** → ø
+_items predicatecommitment_ **output:_k_** → ø
 
 TBD.
 
 #### contract
 
-_items predicate_ **contract:k** → _contract_
+_items predicate_ **contract:_k_** → _contract_
 
 TBD.
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -1430,34 +1430,39 @@ Fails if:
 
 #### issue
 
-_qtyc pred_ **issue** → _contract_
+_qty flv pred_ **issue** → _contract_
 
 1. Pops [point](#point-type) `pred`.
-2. Pops [point](#point-type) `qtyc`.
-3. Creates a value with quantity represented by a [Pedersen commitment](#pedersen-commitment) _qtyc_ and flavor defined by the [predicate](#predicate) `pred` using the following [transcript-based](#transcript) protocol:
+2. Pops [variable](#variable-type) `flv`; if the variable is detached, attaches it.
+3. Pops [variable](#variable-type) `qty`; if the variable is detached, attaches it.
+4. Creates a value with quantity represented by variables `qty` and `flv` for quantity and flavor, respectively. 
+5. Computes the _flavor_ scalar defined by the [predicate](#predicate) `pred` using the following [transcript-based](#transcript) protocol:
     ```
     T = Transcript("ZkVM.issue")
     T.commit("predicate", pred)
     flavor = T.challenge_scalar("flavor")
-    F = flavor·B  (non-blinded Pedersen commitment)
     ```
-4. Adds a 64-bit range proof for the quantity variable to the [constraint system](#constraint-system) (see [Cloak protocol](https://github.com/interstellar/spacesuit/blob/master/spec.md) for the range proof definition). 
-5. Adds an [issue entry](#issue-entry) to the [transaction log](#transaction-log).
-6. Creates a [contract](#contract-type) with the value as the only [payload](#contract-payload), with the predicate `pred`.
+6. Checks that the `flv` has unblinded commitment to `flavor` by [deferring the point operation](#deferred-point-operations):
+    ```
+    F == flavor·B
+    ```
+7. Adds a 64-bit range proof for the `qty` to the [constraint system](#constraint-system) (see [Cloak protocol](https://github.com/interstellar/spacesuit/blob/master/spec.md) for the range proof definition). 
+8. Adds an [issue entry](#issue-entry) to the [transaction log](#transaction-log).
+9. Creates a [contract](#contract-type) with the value as the only [payload](#contract-payload), protected by the predicate `pred`.
 
 The value is now issued into the contract that must be unlocked
 using one of the contract instructions: [`signtx`](#signx), [`delegate`](#delegate) or [`call`](#call).
 
-TBD: the `F` must be provided by the user so the check `F == flavor*B` can be merged with deferred point ops.
-
-TBD: change to accept detached vars
-
-Fails if either `qtyc` or `pred` are not [point types](#point-type).
+Fails if:
+* `pred` is not a [point type](#point-type),
+* `flv` or `qty` are not [variable types](#variable-type).
 
 
 #### borrow
 
 _qtyc flavorc_ **borrow** → _–V +V_
+
+TBD: switch from commitments to variables
 
 1. Pops [points](#point-type) `flavorc`, then `qtyc` from the stack.
 2. Creates [value](#value-type) `+V`, allocating high-level variables for quantity `q1` and flavor `f` in the [constraint system](#constraint-system).

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -813,22 +813,22 @@ The protocol is the following:
 
 The ZkVM state consists of the static attributes and the state machine attributes.
 
-* [Transaction witness](#transaction-witness):
+1. [Transaction witness](#transaction-witness):
     * `version`
     * `mintime` and `maxtime`
     * `program`
     * `tx_signature`
     * `cs_proof`
-* Extension flag (boolean)
-* Uniqueness flag (boolean)
-* Data stack (array of [items](#types))
-* Program stack (array of [programs](#program) with their offsets)
-* Current [program](#program) with its offset
-* [Transaction log](#transaction-log) (array of logged items)
-* Transaction signature verification keys (array of [points](#point-type))
-* [Deferred point operations](#deferred-point-operations)
-* High-level variables: a list of `enum{ detached(point), attached(index) }`
-* [Constraint system](#constraint-system)
+2. Extension flag (boolean)
+3. Uniqueness flag (boolean)
+4. Data stack (array of [items](#types))
+5. Program stack (array of [programs](#program) with their offsets)
+6. Current [program](#program) with its offset
+7. [Transaction log](#transaction-log) (array of logged items)
+8. Transaction signature verification keys (array of [points](#point-type))
+9. [Deferred point operations](#deferred-point-operations)
+10. High-level variables: a list of `enum{ detached(point), attached(index) }`
+11. [Constraint system](#constraint-system)
 
 
 ### VM execution
@@ -844,7 +844,8 @@ The VM is initialized with the following state:
 7. Transaction log is empty.
 8. Array of signature verification keys is empty.
 9. Array of deferred point operations is empty.
-10. Constraint system is empty.
+10. High-level variables: attached variables for [mintime and maxtime](#time-bounds).
+10. Constraint system: empty (time bounds are constants that appear only within linear combinations of actual variables).
 
 Then, the VM executes the current program till completion:
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -101,12 +101,18 @@ When the virtual machine executes a program, it creates and manipulates data of 
 [**plain data types**](#data-types) and [**linear types**](#linear-types), such as [values](#value-type) and
 [contracts](#contract-type).
 
-A [**value**](#value-type) is a specific quantity of a certain _flavor_ that can be
+A [**value**](#value-type) is a specific _quantity_ of a certain _flavor_ that can be
 merged or split, issued or retired, but not otherwise created or destroyed.
 
 A [**contract**] encapsulates a predicate (a public key or a program),
 plus its runtime state, and once created must be executed to completion
 or persisted in the global state for later execution.
+
+Custom logic is represented via programmable [**constraints**](#constraint-type)
+applied to [**variables**](#variable-type). Variables represent quantities and flavors of values,
+[time bounds](#time-bounds) and user-defined secret parameters. All constraints are arranged in
+a single [constraint system](#constraint-system) which is proven to be satisfied after the VM
+has finished execution.
 
 Some ZkVM instructions write proposed updates to the blockchain state
 to the [**transaction log**](#transaction-log), which represents the
@@ -1767,4 +1773,13 @@ an extension instruction “version assertion” that fails execution if
 the version is below a given number (e.g. `4 versionverify`).
 
 
+### Why cloak and borrow take variables and not commitments?
+
+1. it makes sense to reuse variable created by `blind`
+2. txbuilder can keep the secrets assigned to variable instances, so it may be more convenient than remembering preimages for commitments.
+
+
+### Why there is no AND combinator in predicate tree?
+
+The payload of a contract must be provided to the selected branch. If both predicates must be evaluated and both are programs, then which one takes the payload? To avoid ambiguity, AND can be implemented inside a program that can explicitly decide in which order and which parts of payload to process: maybe check some conditions and then delegate the whole payload to a predicate, or split the payload in two parts and apply different predicates to each part. There's [`contract`](#contract) instruction for that delegation.
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -1228,16 +1228,22 @@ TBD: Retires imported [value](#value) with annotation for export.
 
 #### inputs
 
-_snapshots predicates_ **inputs:_m_** → _contracts_
+_inputs predicates_ **inputs:_m_** → _contracts_
 
-TBD.
+1. Pops `m` predicates from the stack.
+2. Pops `m` [input](#input-structure) strings from the stack.
+3. ????
 
 Claims the utxos and unpacks them into contracts.
 Snapshots are linked to the utxos being spent.
 Predicates are sorted randomly vis-a-vis snapshots (to be delinked).
 Resulting contracts are sorted the same way as predicates, and have number stack items corresponding to number of stack items in the snapshots.
 
-Immediate data `k` is encoded as [LE32](#le32).
+Immediate data `m` is encoded as [LE32](#le32).
+
+Fails if:
+1. any of the `predicates` is not a [point type](#point-type), or
+2. any of the `inputs` is not a [string type](#string-type) with exact encoding of [input structure](#input-structure).
 
 #### output
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -105,9 +105,10 @@ When the virtual machine executes a program, it creates and manipulates data of 
 A [**value**](#value-type) is a specific _quantity_ of a certain _flavor_ that can be
 merged or split, issued or retired, but not otherwise created or destroyed.
 
-A [**contract**] encapsulates a predicate (a public key or a program),
-plus its runtime state, and once created must be executed to completion
-or persisted in the global state for later execution.
+A [**contract**](#contract-type) encapsulates a list of data and value items
+protected by a [predicate](#predicate) (a public key or a program) which must be satisfied
+during the VM execution. The contract can be stored in and loaded from the global state
+using [`output`](#output) and [`input`](#input) instructions.
 
 Custom logic is represented via programmable [**constraints**](#constraint-type)
 applied to [**variables**](#variable-type) and [**expressions**](#expression-type)
@@ -1911,7 +1912,20 @@ The programmatic API for creating, indexing and interacting with offers ties all
 
 ### Offer with partial lift
 
-TBD.
+TBD: 
+
+Sketch:
+price = rational X/Y, total value = V, payment: P, change: C;  
+constraint: `(V - C)*X == Y*P`.
+contract unlocks V, `borrow`s and `unblind`s C, outputs C into the same contract,
+borrows P per provided scalar amount, outputs P into recipient's address.
+Returns V, -C and -P to the user. User merges V+(-C) and outputs V-C to its address, provides P into the cloak.
+
+What about zero remainder or dust? Contract can have two branches: partial or full lift,
+and partial lift has minimum remainder to prevent dust.
+
+
+
 
 ### Loan example
 
@@ -2008,4 +2022,14 @@ program structure can be determined right before the use.
 ### Why there is no AND combinator in predicate tree?
 
 The payload of a contract must be provided to the selected branch. If both predicates must be evaluated and both are programs, then which one takes the payload? To avoid ambiguity, AND can be implemented inside a program that can explicitly decide in which order and which parts of payload to process: maybe check some conditions and then delegate the whole payload to a predicate, or split the payload in two parts and apply different predicates to each part. There's [`contract`](#contract) instruction for that delegation.
+
+
+## Open questions
+
+### Do we really need qty/flavor introspection ops?
+
+We currently need them to reblind the received value, but we normally use `borrow` instead of receiving some value and then placing bounds on it.
+
+If we only ever mix all values and borrow necessary payments, then we may reconsider whether we expose these variables at all. 
+
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -222,8 +222,8 @@ P = x * B
 
 where:
 
-* `P` is a verification key,
-* `x` is a signing key (secret scalar),
+* `P` is the verification key,
+* `x` is the secret signing key (secret scalar),
 * `B` is the [primary base point](#base-points).
 
 
@@ -514,7 +514,7 @@ Extensions:
 
 ## Instructions
 
-Instructions               | Stack diagram                              | Effects
+Instruction                | Stack diagram                              | Effects
 ---------------------------|--------------------------------------------|----------------------------------
 [**Data**](#data-instructions)  |                                       |
 [`scalar:x`](#scalar)      |                 ø → _scalar_               | 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -1763,6 +1763,7 @@ Bytecode creating the offer:
 <value> <offer predicate> output:1 "Offer: 1 BTC for 3745 USD" data
 ```
 
+The programmatic API for creating, indexing and interacting with offers ties all parts together.
 
 ### Offer with partial lift
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -211,8 +211,10 @@ Predicates can be selected from a tree of alternatives via [`left`](#left) and [
 
 ### Verification key
 
-A _verification key_ (aka "public key") is a commitment to a _signing key_ (secret [scalar](#scalar-type))
+A _verification key_ `P` is a commitment to a secret [scalar](#scalar-type) `x` (_signing key_)
 using the primary [base point](#base-points).
+
+Verification keys are used to construct [predicates](#predicate).
 
 ```
 P = x * B
@@ -223,11 +225,6 @@ where:
 * `P` is a verification key,
 * `x` is a signing key (secret scalar),
 * `B` is the [primary base point](#base-points).
-
-#### See also
-
-* [Predicate](#predicate)
-* [Signature](#signature)
 
 
 ### Program
@@ -261,13 +258,8 @@ Examples of variables: [value quantities](#value-type) and [time bounds](#time-b
 
 Cleartext [scalars](#scalar-type) can be turned into a `Variable` type using the [`const`](#const) instruction.
 
-#### See also
 
-* [Constraint](#constraint-type)
-* [Constraint system](#constraint-system)
-
-
-### Constraint Type
+### Constraint type
 
 _Constraint_ is a statement in the [constraint system](#constraint-system) that constrains
 a linear combination of variables to zero.
@@ -276,11 +268,6 @@ Constraints are created using the [`zkeq`](#zkeq) instruction over two [variable
 
 Constraints can be combined using logical [`and`](#and) and [`or`](#or) instructions and added to the constraint
 system using the [verify](#verify) instruction.
-
-#### See also
-
-* [Variable](#variable-type)
-* [Constraint system](#constraint-system)
 
 
 ### Commitment

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -423,7 +423,7 @@ T.commit("L", L)
 T.commit("R", R)
 f = T.challenge_scalar("f")
 OR(L,R) = L + f·B
-```
+``` 
 
 The choice between the branches is performed using [`left`](#left) and [`right`](#right) instructions.
 
@@ -874,8 +874,6 @@ The recipient can copy the proof about the nonce `q`: `Q || R_q || s_q`
 and use it in their [reblinding proof](#reblinding-proof).
 
 #### Reblinding proof
-
-TBD. Prove `V2-V1 = f*B2 - p*Q` where `Q=q*B2` proof is copied from blinding tx, `P=p*B2` is pre-agreed on, and `f` is the new factor.
 
 Proves that a commitment `V2` retains the same committed value `v` as `V1`, but subtracts blinding factor `p·Q` and adds another blinding factor `f·B2`. 
 
@@ -1543,6 +1541,7 @@ _items... predicate_ **output:_k_** → ø
 1. Pops [`predicate`](#predicate) from the stack.
 2. Pops `k` items from the stack.
 3. Adds an [output entry](#output-entry) to the [transaction log](#transaction-log).
+4. For each [value](#value-type) in the output, if any quantity or flavor variable is detached, attaches that variable to the constraint system.
 
 Immediate data `k` is encoded as [LE32](#le32).
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -482,6 +482,7 @@ and can only contain [portable types](#portable-types).
 
 Note: the [plain data](#data-types) items are encoded as VM instructions that produce the corresponding item.
 
+
 ### Constraint system
 
 The part of the [VM state](#vm-state) that implements
@@ -858,19 +859,19 @@ Each instruction defines the format for immediate data. See the reference below 
 
 Code | Instruction                | Stack diagram                              | Effects
 -----|----------------------------|--------------------------------------------|----------------------------------
- |     [**Data**](#data-instructions)                 |                        |
+ |     [**Data**](#data-instructions)                 |                        |
 0x00 | [`scalar:x`](#scalar)      |                 ø → _scalar_               | 
 0x01 | [`point:x`](#point)        |                 ø → _point_                | 
 0x02 | [`string:n:x`](#string)    |                 ø → _string_               | 
- |                                |                                            |
- |     [**Scalars**](#scalar-instructions)            |                        | 
+ |                                |                                            |
+ |     [**Scalars**](#scalar-instructions)            |                        | 
 0x?? | [`neg`](#neg)              |               _a_ → _\|G\|–a_              | 
 0x?? | [`add`](#add)              |             _a b_ → _a+b mod \|G\|_        | 
 0x?? | [`mul`](#mul)              |             _a b_ → _a·b mod \|G\|_        | 
 0x?? | [`eq`](#eq)                |             _a b_ → ø                      | Fails if _a_ ≠ _b_.
 0x?? | [`range:n`](#range)        |               _a_ → _a_                    | Fails if _a_ is not in range [0..2^64-1]
- |                                |                                            |
- |     [**Constraints**](#constraint-system-instructions)  |                   | 
+ |                                |                                            |
+ |     [**Constraints**](#constraint-system-instructions)  |                   | 
 0x?? | [`var`](#var)              |           _point_ → _var_                  | Adds an external variable to [CS](#constraint-system)
 0x?? | [`const`](#var)            |          _scalar_ → _var_                  | 
 0x?? | [`mintime`](#mintime)      |                 ø → _var_                  |
@@ -886,8 +887,8 @@ Code | Instruction                | Stack diagram                              |
 0x?? | [`verify`](#verify)        |      _constraint_ → ø                      | Modifies [CS](#constraint-system) 
 0x?? | [`encrypt`](#encrypt)      |     _X F V proof_ → _V_                    | [Defers point operations](#deferred-point-operations)
 0x?? | [`decrypt`](#decrypt)      |        _V scalar_ → _V_                    | [Defers point operations](#deferred-point-operations))
- |                                |                                            |
- |     [**Values**](#value-instructions)              |                        |
+ |                                |                                            |
+ |     [**Values**](#value-instructions)              |                        |
 0x?? | [`issue`](#issue)          |       _qtyc pred_ → _contract_             | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 0x?? | [`borrow`](#borrow)        |    _qtyc flavorc_ → _–V +V_                | Modifies [CS](#constraint-system)
 0x?? | [`retire`](#retire)        |           _value_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
@@ -896,8 +897,8 @@ Code | Instruction                | Stack diagram                              |
 0x?? | [`cloak:m:n`](#cloak)      | _signedvalues commitments_ → _values_      | Modifies [CS](#constraint-system)
 0x?? | [`import`](#import)        |             _???_ → _value_                | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 0x?? | [`export`](#export)        |       _value ???_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
- |                                |                                            |
- |      [**Contracts**](#contract-instructions)        |                        |
+ |                                |                                            |
+ |     [**Contracts**](#contract-instructions)        |                        |
 0x?? | [`inputs:m`](#inputs)      | _snapshots... predicates..._ → _contracts_ | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 0x?? | [`output:k`](#output)      | _items... predicatecommitment_ → ø         | Modifies [tx log](#transaction-log)
 0x?? | [`contract:k`](#contract)  | _items... predicate_ → _contract_          | 
@@ -908,8 +909,8 @@ Code | Instruction                | Stack diagram                              |
 0x?? | [`left`](#left)            |       _contract A B_ → _contract’_         | [Defers point operations](#deferred-point-operations)
 0x?? | [`right`](#right)          |       _contract A B_ → _contract’_         | [Defers point operations](#deferred-point-operations)
 0x?? | [`delegate`](#delegate)    |  _contract prog sig_ → _results..._        | [Defers point operations](#deferred-point-operations)
- |                                |                                            |
- |     [**Stack**](#stack-instructions)               |                        | 
+ |                                |                                            |
+ |     [**Stack**](#stack-instructions)               |                        |
 0x?? | [`dup`](#dup)              |               _x_ → _x x_                  |
 0x?? | [`drop`](#drop)            |               _x_ → ø                      |
 0x?? | [`peek:k`](#peek)          |     _x[k] … x[0]_ → _x[k] ... x[0] x[k]_   |

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -99,11 +99,11 @@ broad categories: [data types](#data-types) and [linear types](#linear-types).
 
 Data types can be freely created, copied, and destroyed.
 
-* [Scalars](#scalars)
-* [Points](#points)
-* [Strings](#strings)
-* [Variables](#variables)
-* [Constraints](#constraint)
+* [Scalar](#scalar-type)
+* [Point](#point-type)
+* [String](#string-type)
+* [Variable](#variable-type)
+* [Constraint](#constraint-type)
 
 
 ### Linear types
@@ -111,31 +111,31 @@ Data types can be freely created, copied, and destroyed.
 Linear types are subject to special rules as to when and how they may be created
 and destroyed, and may never be copied.
 
-* [Contracts](#contracts)
-* [Signed Values](#signed-values)
-* [Values](#values)
+* [Contract](#contract-type)
+* [Signed Value](#signed-value-type)
+* [Value](#value-type)
 
 
 ### Portable types
 
-The items of the following types can be _ported_ across transactions via [outputs](#outputs):
+The items of the following types can be _ported_ across transactions via [outputs](#output-structure):
 
 * [Plain data types](#data-types):
-    * [Scalars](#scalars)
-    * [Points](#points)
-    * [Strings](#strings)
-* [Values](#values)
+    * [Scalar](#scalar-type)
+    * [Point](#point-type)
+    * [String](#string-type)
+* [Value](#value-type)
 
-The [Signed Value](#signed-values) is not portable because it is not proven to be non-negative.
+The [Signed Value](#signed-value-type) is not portable because it is not proven to be non-negative.
 
-The [Contract](#contracts) is not portable because it must be satisfied within the current transaction
-or [output](#outputs) its contents itself.
+The [Contract](#contract-type) is not portable because it must be satisfied within the current transaction
+or [output](#output-structure) its contents itself.
 
-The [Variable](#variables) and [Constraint](#constraint) types have no meaning outside the VM state
+The [Variable](#variable-type) and [Constraint](#constraint-type) types have no meaning outside the VM state
 and its constraint system and therefore cannot be ported between transactions.
 
 
-### Scalars
+### Scalar type
 
 A _scalar_ is an integer modulo [Ristretto group](https://ristretto.group) order `2^252 + 27742317777372353535851937790883648493`.
 
@@ -143,7 +143,7 @@ Scalars are encoded as 32-byte arrays using little-endian notation.
 Every scalar in the VM is guaranteed to be in a canonical (reduced) form.
 
 
-### Points
+### Point type
 
 A _point_ is an element in the [Ristretto group](https://ristretto.group).
 
@@ -164,14 +164,15 @@ Both base points are orthogonal (the discrete log between them is unknown)
 and used in [commitments](#commitment), 
 [verification keys](#verification-key) and [predicates](#predicate).
 
-### Strings
+
+### String type
 
 A _string_ is a variable-length byte array used to represent signatures, proofs and programs.
 
 Strings cannot be larger than the entire transaction program and cannot be longer than `2^32-1`.
 
 
-### Contracts
+### Contract type
 
 A contract is a [predicate](#predicate) and a [payload](#payload) guarded by that predicate.
 
@@ -185,17 +186,17 @@ recorded in the [transaction log](#transaction-log).
 
 ### Payload
 
-A list of [items](#types) stored in the [contract](#contracts) or [output](#outputs).
+A list of [items](#types) stored in the [contract](#contract-type) or [output](#output-structure).
 
-Payload of a [contract](#contracts) may contain arbitrary [types](#types),
-but in the [output](#outputs) only the [portable types](#portable-types) are allowed.
+Payload of a [contract](#contract-type) may contain arbitrary [types](#types),
+but in the [output](#output-structure) only the [portable types](#portable-types) are allowed.
 
 
 ### Predicate
 
-A _predicate_ is a representation of a condition that unlocks the [contract](#contracts).
+A _predicate_ is a representation of a condition that unlocks the [contract](#contract-type).
 
-Predicate is encoded as a [point](#points) which can itself represent:
+Predicate is encoded as a [point](#point-type) which can itself represent:
 
 * a verification key,
 * a set of verification keys,
@@ -213,7 +214,7 @@ Predicates can be selected from a tree of alternatives via [`left`](#left) and [
 
 ### Verification key
 
-A _verification key_ (aka "public key") is a commitment to a _signing key_ (secret [scalar](#scalars))
+A _verification key_ (aka "public key") is a commitment to a _signing key_ (secret [scalar](#scalar-type))
 using the primary [base point](#base-points).
 
 ```
@@ -249,45 +250,45 @@ See the [instruction set](#instructions) for definition of the immediate data fo
 The part of the [VM state](#vm-state) that implements
 [Bulletprofs Rank-1 Constraint System](https://doc-internal.dalek.rs/develop/bulletproofs/notes/r1cs_proof/index.html).
 
-Constraint system keeps track of [variables](#variables) and [constraints](#constraint).
+Constraint system keeps track of [variables](#variable-type) and [constraints](#constraint-type).
 
-### Variables
+### Variable type
 
 _Variable_ is a linear combination of high-level and low-level variables in the [constraint system](#constraint-system).
 
 Variables can be added and multiplied, producing new variables (see [`zkadd`](#zkadd), [`zkneg`](#zkneg), [`zkmul`](#zkmul), [`scmul`](#scmul) and [`zkrange`](#zkrange) instructions).
 
-Equality of two variables is checked by creating a [constraint](#constraint) using the [`zkeq`](#zkeq) instruction.
+Equality of two variables is checked by creating a [constraint](#constraint-type) using the [`zkeq`](#zkeq) instruction.
 
-Examples of variables: [value quantities](#values) and [time bounds](#time-bounds).
+Examples of variables: [value quantities](#value-type) and [time bounds](#time-bounds).
 
-Cleartext [scalars](#scalars) can be turned into a `Variable` type using the [`const`](#const) instruction.
+Cleartext [scalars](#scalar-type) can be turned into a `Variable` type using the [`const`](#const) instruction.
 
 #### See also
 
-* [Constraint](#constrain)
+* [Constraint](#constraint-type)
 * [Constraint system](#constraint-system)
 
 
-### Constraint
+### Constraint Type
 
 _Constraint_ is a statement in the [constraint system](#constraint-system) that constrains
 a linear combination of variables to zero.
 
-Constraints are created using the [`zkeq`](#zkeq) instruction over two [variables](#variables).
+Constraints are created using the [`zkeq`](#zkeq) instruction over two [variables](#variable-type).
 
 Constraints can be combined using logical [`and`](#and) and [`or`](#or) instructions and added to the constraint
 system using the [verify](#verify) instruction.
 
 #### See also
 
-* [Variable](#variable)
+* [Variable](#variable-type)
 * [Constraint system](#constraint-system)
 
 
 ### Commitment
 
-A _commitment_ is a Pedersen commitment to a secret [scalar](#scalars) represented by a [point](#points):
+A _commitment_ is a Pedersen commitment to a secret [scalar](#scalar-type) represented by a [point](#point-type):
 
 ```
 P = Com(v, f) = v*B + f*B2
@@ -300,7 +301,7 @@ where:
 * `f` is a secret blinding factor (scalar),
 * `B` and `B2` are [base points](#base-points).
 
-Commitments can be used to allocate new [variables](#variables) using the [`var`](#var) instruction.
+Commitments can be used to allocate new [variables](#variable-type) using the [`var`](#var) instruction.
 
 Commitments can be proven to use a pre-determined blinding factor using [`encrypt`](#encrypt) and 
 [`decrypt`](#decrypt) instructions.
@@ -312,15 +313,15 @@ Each transaction is explicitly bound to a range of _minimum_ and _maximum_ time.
 
 Each bound is in _seconds_ since Jan 1st, 1970 (UTC), represented by an unsigned 64-bit integer.
 
-Time bounds are available in the transaction as [variables](#variables) provided by the instructions
+Time bounds are available in the transaction as [variables](#variable-type) provided by the instructions
 [`mintime`](#mintime) and [`maxtime`](#maxtime).
 
 
-### Values
+### Value type
 
 A value is a [linear type](#linear-types) representing a pair of *quantity* and *flavor*.
 
-Both quantity and flavor are represented as [scalars](#scalars).
+Both quantity and flavor are represented as [scalars](#scalar-type).
 Quantity is guaranteed to be in a 64-bit range (`[0..2^64-1]`).
 
 Values are created with [`issue`](#issue) and destroyed with [`retire`](#retire).
@@ -328,29 +329,29 @@ Values are created with [`issue`](#issue) and destroyed with [`retire`](#retire)
 A value can be merged and split together with other values using a [`cloak`](#cloak) instruction.
 Only values having the same flavor can be merged.
 
-Values are secured by “locking them up” inside [contracts](#contracts).
+Values are secured by “locking them up” inside [contracts](#contract-type).
 
 Contracts can also require payments by creating outputs using _borrowed_ values.
-[`borrow`](#borrow) instruction produces two items: a positive value and a negative [signed value](#signed-values),
+[`borrow`](#borrow) instruction produces two items: a positive value and a negative [signed value](#signed-value-type),
 which must be cleared using appropriate combination of positive values.
 
 
-### Signed values
+### Signed value type
 
-A signed value is an extension of the [value](#values) type where
+A signed value is an extension of the [value](#value-type) type where
 quantity is guaranteed to be in a 65-bit range (`[-(2^64-1)..2^64-1]`).
 
-The subtype [Value](#values) is most commonly used because it guarantees the non-negative quantity
-(for instance, [`output`](#output) instruction only permits positive [values](#values)),
+The subtype [Value](#value-type) is most commonly used because it guarantees the non-negative quantity
+(for instance, [`output`](#output) instruction only permits positive [values](#value-type)),
 and the signed value is only used as an output of [`borrow`](#borrow) and as an input to [`cloak`](#cloak).
 
 
 ### Signature
 
-Signature is a Schnorr proof of knowledge of a secret [scalar](#scalars) corresponding
+Signature is a Schnorr proof of knowledge of a secret [scalar](#scalar-type) corresponding
 to a [verification key](#verification-key).
 
-Signature is encoded as a 64-byte [string](#strings).
+Signature is encoded as a 64-byte [string](#string-type).
 
 The signature verification protocol is the following:
 
@@ -391,8 +392,8 @@ TBD: contract snapshot
 
 A proof of satisfiability of a [constraint system](#constraint-system) built during the VM execution.
 
-The proof is represented by a collection of [points](#points) and [scalars](#scalars)
-encoded in a single [string](#strings).
+The proof is represented by a collection of [points](#point-type) and [scalars](#scalar-type)
+encoded in a single [string](#string-type).
 
 The proof is provided to the [`finalize`](#finalize) instruction at which point the transaction is
 fully formed and the proof can be verified.


### PR DESCRIPTION
This adds a first draft of the ZkVM spec and the outline of the related protocols.

The goal is to start with the concepts we love about TxVM, remove all the implementation details and rebuild from first principles.

This is a proposal and not a finished design. When this is merged, **do not assume it is close to being final**. We want to evolve the design together, and have a clean record of all design considerations along the way.

[📄 ZkVM specification](https://github.com/interstellar/zkvm/blob/zkvm_spec/spec/ZkVM.md)