### PR TITLE
Address quirks in the spec based on implementation draft

### DIFF
--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -497,7 +497,7 @@ Input is serialized as [output](#output-structure) with extra 32 bytes containin
 this output’s [transaction ID](#transaction-id).
 
 ```
-       Input  =  PreviousOutput || PreviousTxID
+       Input  =  PreviousTxID || PreviousOutput
 PreviousTxID  =  <32 bytes>
 
 ```
@@ -523,7 +523,7 @@ Output represents a _snapshot_ of a [contract](#contract-type)
 and can only contain [portable types](#portable-types).
 
 ```
-      Output  =  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]  ||  Predicate
+      Output  =  Predicate  ||  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]
    Predicate  =  <32 bytes>
         Item  =  enum { Data, Value }
         Data  =  0x00  ||  LE32(len)  ||  <bytes>
@@ -1016,7 +1016,10 @@ The VM is initialized with the following state:
 8. Array of signature verification keys is empty.
 9. Array of deferred point operations is empty.
 10. High-level variables: empty.
-11. Constraint system: empty (time bounds are constants that appear only within linear combinations of actual variables).
+11. Constraint system: empty (time bounds are constants that appear only within linear combinations of actual variables), with [transcript](#transcript) initialized with label `ZkVM.r1cs`:
+    ```
+    r1cs_transcript = Transcript("ZkVM.r1cs")
+    ```
 
 Then, the VM executes the current program till completion:
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -1599,7 +1599,6 @@ _items... predicate_ **output:_k_** → ø
 1. Pops [`predicate`](#predicate) from the stack.
 2. Pops `k` items from the stack.
 3. Adds an [output entry](#output-entry) to the [transaction log](#transaction-log).
-4. For each [value](#value-type) in the output, if any quantity or flavor variable is detached, attaches that variable to the constraint system.
 
 Immediate data `k` is encoded as [LE32](#le32).
 

--- a/spec/ZkVM.md
+++ b/spec/ZkVM.md
@@ -523,7 +523,7 @@ Output represents a _snapshot_ of a [contract](#contract-type)
 and can only contain [portable types](#portable-types).
 
 ```
-       Input  =  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]  ||  Predicate
+      Output  =  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]  ||  Predicate
    Predicate  =  <32 bytes>
         Item  =  enum { Data, Value }
         Data  =  0x00  ||  LE32(len)  ||  <bytes>
@@ -1686,7 +1686,7 @@ or if the third from the top item is not a [contract](#contract-type).
 
 #### right
 
-_contract(P) L R_ **left** → _contract(R)_
+_contract(P) L R_ **right** → _contract(R)_
 
 1. Pops the right [predicate](#predicate) `R`, then the left [predicate](#predicate) `L`.
 2. Reads the [predicate](#predicate) `P` from the contract.


### PR DESCRIPTION
As I've implemented a few bits of VM in #4, I've discovered a few improvements to the spec:

1. Fixed-length fields in input and output structures are moved towards the beginning to make parsing simpler.
2. Missing r1cs transcript label is specified.
3. Removed excess requirement to attach variables inside `output`.
4. Typo in the stack diagram for `right` is fixed.