### PR TITLE
add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: rust
+cache: cargo
+
+rust:
+  - nightly
+
+env:
+  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES=''
+  # run cargo bench with a filter that matches no benchmarks.
+  # this ensures the benchmarks build but doesn't run them on the CI server.
+  - TEST_COMMAND=bench EXTRA_FLAGS='"DONTRUNBENCHMARKS"'
+
+before_script:
+  - rustup component add rustfmt-preview
+
+matrix:
+  fast_finish: true
+  include:
+  - rust: nightly-2018-12-31
+    before_script:
+    - rustup component add rustfmt-preview
+    script:
+    - cargo fmt --all -- --check
+
+script:
+  - cargo $TEST_COMMAND --features="$FEATURES" $EXTRA_FLAGS

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -125,7 +125,7 @@ mod tests {
         let left = Predicate(gens.B.compress());
         let right = Predicate(gens.B_blinding.compress());
 
-        let pred = left.or(&right, ).unwrap();
+        let pred = left.or(&right).unwrap();
         let op = pred.prove_or(&right, &left);
         assert!(op.verify().is_err());
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -19,11 +19,7 @@ pub struct Signature {
 
 impl Signature {
     /// Verifies a signature for a single key
-    pub fn verify_single(
-        &self,
-        transcript: &mut Transcript,
-        pubkey: VerificationKey,
-    ) -> PointOp {
+    pub fn verify_single(&self, transcript: &mut Transcript, pubkey: VerificationKey) -> PointOp {
         self.verify_aggregated(transcript, &[pubkey])
     }
 
@@ -146,7 +142,6 @@ impl Signature {
 pub struct VerificationKey(pub CompressedRistretto);
 
 impl VerificationKey {
-
     // Constructs a VerificationKey from the private key.
     pub fn from_secret(privkey: &Scalar) -> Self {
         let gens = PedersenGens::default();
@@ -162,10 +157,7 @@ mod tests {
     fn empty() {
         let mut transcript = Transcript::new(b"empty");
         let sig = Signature::sign_aggregated(&mut transcript, &[]);
-        assert!(sig
-            .verify_aggregated(&mut transcript, &[])
-            .verify()
-            .is_ok());
+        assert!(sig.verify_aggregated(&mut transcript, &[]).verify().is_ok());
     }
 
     #[test]
@@ -179,10 +171,7 @@ mod tests {
         };
 
         let mut transcript = Transcript::new(b"single_signature");
-        assert!(sig
-            .verify_single(&mut transcript, pubkey)
-            .verify()
-            .is_ok());
+        assert!(sig.verify_single(&mut transcript, pubkey).verify().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Add Travis to the `zkvm` repo, configured to check `cargo fmt` and run tests.