### PR TITLE
vm: make Data cloneable, add FrozenContract, FrozenItem and FrozenValue

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -4,7 +4,7 @@ use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::types::Data;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Instruction {
     Push(Data), // size of the string
     Drop,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -265,7 +265,7 @@ where
         }
         let item_idx = self.stack.len() - i - 1;
         let item = match &self.stack[item_idx] {
-            Item::Data(x) => Item::Data(x.tbd_clone()?),
+            Item::Data(x) => Item::Data(x.clone()),
             Item::Variable(x) => Item::Variable(x.clone()),
             Item::Expression(x) => Item::Expression(x.clone()),
             Item::Constraint(x) => Item::Constraint(x.clone()),


### PR DESCRIPTION
This adds necessary witness types, but does not add any conversion methods for them into non-frozen counterparts. That's TBD when we do the proving API.

Closes #23.